### PR TITLE
Convert to Flutter package and add Ref.scoped

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Dart Test
+name: Test
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -8,7 +8,7 @@ on:
     workflow_dispatch:
     pull_request:
         branches: ["main"]
-        types: [ready_for_review, review_requested] # Restrict to non-draft PRs
+        types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
     spell-check:
@@ -17,29 +17,22 @@ jobs:
             includes: "*.md"
             modified_files_only: true
 
-    build:
+    test:
         runs-on: ubuntu-latest
+
+        if: github.event.pull_request.draft == false
 
         steps:
             - name: 📚 Git Checkout
               uses: actions/checkout@v4
 
-            - name: 🎯 Setup Dart
-              uses: dart-lang/setup-dart@v1
+            - uses: subosito/flutter-action@v2
 
-            - name: 📦 Install Dependencies
-              run: dart pub get
-
-            - name: ✨ Check Formatting
-              run: dart format --set-exit-if-changed .
-
-            - name: 🕵️ Analyze
-              run: dart analyze --fatal-infos --fatal-warnings lib test
-
-            - name: 🧪 Run Tests
+            - name: Build and Test
               run: |
-                  dart pub global activate coverage 1.2.0
-                  dart test -j 4 --coverage=coverage && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info
+                  flutter pub get
+                  flutter analyze
+                  flutter test --coverage
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ dart pub add lite_ref
 
 A `ScopedRef` is a reference that needs a build context to access its instance. This is an alternative to `Provider` for classes that don't rebuild widgets. eg: Controllers, Repositories, Services, etc.
 
--   Wrap your app with a `LiteRefScope`:
+-   Wrap your app or a subtree with a `LiteRefScope`:
 
     ```dart
     runApp(
@@ -64,7 +64,7 @@ A `ScopedRef` is a reference that needs a build context to access its instance. 
 -   Override it for a subtree:
 
     You can override the instance for a subtree by using `overrideWith`. This is useful for testing.
-    In the example below all calls to `settingsServiceRef.of(context)` will return `MockSettingsService`.
+    In the example below, all calls to `settingsServiceRef.of(context)` will return `MockSettingsService`.
 
     ```dart
     LiteRefScope(

--- a/example/flutter_example/lib/deps.dart
+++ b/example/flutter_example/lib/deps.dart
@@ -2,8 +2,8 @@ import 'package:flutter_example/settings/controller.dart';
 import 'package:flutter_example/settings/service.dart';
 import 'package:lite_ref/lite_ref.dart';
 
-final settingsServiceRef = Ref.singleton(create: SettingsService.new);
+final settingsServiceRef = Ref.scoped((ctx) => SettingsService());
 
-final settingsControllerRef = Ref.singleton(
-  create: () => SettingsController(settingsServiceRef()),
+final settingsControllerRef = Ref.scoped(
+  (ctx) => SettingsController(settingsServiceRef(ctx)),
 );

--- a/example/flutter_example/lib/main.dart
+++ b/example/flutter_example/lib/main.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_example/deps.dart';
 import 'package:flutter_example/settings/view.dart';
+import 'package:lite_ref/lite_ref.dart';
 
 void main(List<String> args) {
-  runApp(const MyApp());
+  runApp(LiteRefScope(child: const MyApp()));
 }
 
 class MyApp extends StatelessWidget {
@@ -11,7 +12,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller = settingsControllerRef();
+    final controller = settingsControllerRef(context);
     return FutureBuilder(
       future: controller.loadSettings(),
       builder: (context, snapshot) {

--- a/example/flutter_example/lib/settings/view.dart
+++ b/example/flutter_example/lib/settings/view.dart
@@ -11,7 +11,7 @@ class SettingsView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller = settingsControllerRef();
+    final controller = settingsControllerRef(context);
 
     return Scaffold(
       appBar: MyAppBar(context, title: 'Settings'),
@@ -22,7 +22,7 @@ class SettingsView extends StatelessWidget {
         // When a user selects a theme from the dropdown list, the
         // SettingsController is updated, which rebuilds the MaterialApp.
         child: ListenableBuilder(
-          listenable: settingsControllerRef(),
+          listenable: controller,
           builder: (context, snapshot) {
             return DropdownButton<ThemeMode>(
               // Read the selected themeMode from the controller

--- a/example/flutter_example/pubspec.yaml
+++ b/example/flutter_example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     flutter:
         sdk: flutter
     lite_ref:
+        path: ../../
 
 dev_dependencies:
     flutter_test:

--- a/example/flutter_example/test/widget_test.dart
+++ b/example/flutter_example/test/widget_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_example/main.dart';
 import 'package:flutter_example/settings/controller.dart';
 import 'package:flutter_example/settings/service.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lite_ref/lite_ref.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockSettingsService extends Mock implements SettingsService {}
@@ -20,11 +21,6 @@ class MockSettingsController extends Mock implements SettingsController {}
 void main() {
   final mockSettingsService = MockSettingsService();
   final mockSettingsController = MockSettingsController();
-
-  setUp(() {
-    settingsServiceRef.overrideWith(() => mockSettingsService);
-    settingsControllerRef.overrideWith(() => mockSettingsController);
-  });
 
   testWidgets('Controller test', (WidgetTester tester) async {
     when(mockSettingsController.loadSettings).thenAnswer((_) async {});
@@ -36,7 +32,15 @@ void main() {
     );
 
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      LiteRefScope(
+        overrides: [
+          settingsServiceRef.overrideWith((_) => mockSettingsService),
+          settingsControllerRef.overrideWith((_) => mockSettingsController),
+        ],
+        child: const MyApp(),
+      ),
+    );
 
     await tester.pumpAndSettle();
 

--- a/lib/lite_ref.dart
+++ b/lib/lite_ref.dart
@@ -3,4 +3,5 @@ library lite_ref;
 
 export 'src/async/async.dart';
 export 'src/ref.dart';
+export 'src/scoped/scoped.dart';
 export 'src/sync/sync.dart';

--- a/lib/src/async/async.dart
+++ b/lib/src/async/async.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 part 'singleton.dart';
 part 'transient.dart';

--- a/lib/src/ref.dart
+++ b/lib/src/ref.dart
@@ -1,8 +1,17 @@
 import 'package:lite_ref/src/async/async.dart';
+import 'package:lite_ref/src/scoped/scoped.dart';
 import 'package:lite_ref/src/sync/sync.dart';
 
 /// {@macro ref}
 abstract class Ref {
+  /// Creates a new [ScopedRef] which requires a context to access the instance.
+  static ScopedRef<T> scoped<T>(
+    CtxCreateFn<T> create, {
+    DisposeFn<T>? dispose,
+  }) {
+    return ScopedRef<T>(create, dispose: dispose);
+  }
+
   /// Creates a new [SingletonRef] which always return the same instance.
   static SingletonRef<T> singleton<T>(T Function() create) {
     return SingletonRef<T>(create);

--- a/lib/src/scoped/ref.dart
+++ b/lib/src/scoped/ref.dart
@@ -1,0 +1,89 @@
+// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
+
+part of 'scoped.dart';
+
+/// The function used to create an instance of [T].
+typedef CtxCreateFn<T> = T Function(BuildContext);
+
+/// The function called when the [ScopedRef] is disposed.
+typedef DisposeFn<T> = void Function(T);
+
+/// A [ScopedRef] is a reference that needs a context to access the instance.
+class ScopedRef<T> {
+  ///  Creates a new [ScopedRef] which always return a new instance.
+  ScopedRef(CtxCreateFn<T> create, {DisposeFn<T>? dispose})
+      : _create = create,
+        _onDispose = dispose,
+        _id = Object();
+
+  ScopedRef._(CtxCreateFn<T> create, Object id, {DisposeFn<T>? dispose})
+      : _create = create,
+        _id = id,
+        _onDispose = dispose;
+
+  final Object _id;
+
+  DisposeFn<T>? _onDispose;
+
+  T? _instance;
+
+  final CtxCreateFn<T> _create;
+
+  void _init(BuildContext context) {
+    _instance = _create(context);
+  }
+
+  /// Returns a new instance of [T].
+  T of(BuildContext context) {
+    final box = LiteRefScope._of(context);
+
+    final existing = box._cache[_id];
+
+    if (existing != null) {
+      return existing._instance as T;
+    }
+
+    final refOverride = box._overrides?.lookup(this);
+
+    if (refOverride != null) {
+      refOverride._init(context);
+      box._cache[_id] = refOverride;
+      return refOverride._instance as T;
+    }
+
+    _init(context);
+
+    box._cache[_id] = this;
+
+    return _instance as T;
+  }
+
+  /// Equivalent to calling the [of(context)] getter.
+  T call(BuildContext context) => of(context);
+
+  /// Returns a new ScopedRef with a different [create] function.
+  /// When used with a [LiteRefScope], any child widget that accesses
+  /// the instance will use the new [create] function.
+  ScopedRef<T> overrideWith(CtxCreateFn<T> create) {
+    return ScopedRef._(create, _id, dispose: _onDispose);
+  }
+
+  /// Clears the instance and calls the dispose function if it exists.
+  void _dispose() {
+    if (_instance == null) return;
+    _onDispose?.call(_instance as T);
+    _instance = null;
+    _onDispose = null;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (runtimeType != other.runtimeType) return false;
+    if (other is ScopedRef<T>) return _id == other._id;
+    return false;
+  }
+
+  @override
+  int get hashCode => _id.hashCode;
+}

--- a/lib/src/scoped/ref.dart
+++ b/lib/src/scoped/ref.dart
@@ -33,7 +33,7 @@ class ScopedRef<T> {
     _instance = _create(context);
   }
 
-  /// Returns a new instance of [T].
+  /// Returns the instance of [T] in the current scope.
   T of(BuildContext context) {
     final box = LiteRefScope._of(context);
 
@@ -62,13 +62,12 @@ class ScopedRef<T> {
   T call(BuildContext context) => of(context);
 
   /// Returns a new ScopedRef with a different [create] function.
-  /// When used with a [LiteRefScope], any child widget that accesses
+  /// When used with a [LiteRefScope] overrides, any child widget that accesses
   /// the instance will use the new [create] function.
   ScopedRef<T> overrideWith(CtxCreateFn<T> create) {
     return ScopedRef._(create, _id, dispose: _onDispose);
   }
 
-  /// Clears the instance and calls the dispose function if it exists.
   void _dispose() {
     if (_instance == null) return;
     _onDispose?.call(_instance as T);

--- a/lib/src/scoped/scope_widget.dart
+++ b/lib/src/scoped/scope_widget.dart
@@ -30,7 +30,7 @@ class LiteRefScope extends InheritedWidget {
   }
 
   static Never _notFound() {
-    throw ArgumentError(
+    throw StateError(
       '''
   You must wrap your app with a `LiteRefScope`.
 

--- a/lib/src/scoped/scope_widget.dart
+++ b/lib/src/scoped/scope_widget.dart
@@ -1,0 +1,62 @@
+part of 'scoped.dart';
+
+typedef _Cache = Map<Object, ScopedRef<dynamic>>;
+
+/// Dependency injection of [ScopedRef]s.
+class LiteRefScope extends InheritedWidget {
+  /// Create a new [LiteRefScope]
+  LiteRefScope({
+    required super.child,
+    super.key,
+    List<ScopedRef<dynamic>>? overrides,
+  }) : _overrides = overrides?.toSet();
+
+  /// The [ScopedRef]s that are overridden by this [LiteRefScope].
+  final Set<ScopedRef<dynamic>>? _overrides;
+  late final _cache = _Cache();
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
+
+  @override
+  InheritedElement createElement() => _Element(this);
+
+  static LiteRefScope? _maybeOf(BuildContext context) {
+    final element =
+        context.getElementForInheritedWidgetOfExactType<LiteRefScope>();
+    return element is _Element ? element.box : null;
+  }
+
+  static Never _notFound() {
+    throw ArgumentError(
+      '''
+  You must wrap your app with a `LiteRefScope`.
+
+  runApp(
+    LiteRefScope(
+      child: MyApp(),
+    ),
+  );
+  ''',
+    );
+  }
+
+  static LiteRefScope _of(BuildContext context) =>
+      _maybeOf(context) ?? _notFound();
+}
+
+class _Element extends InheritedElement {
+  _Element(LiteRefScope super.widget);
+
+  LiteRefScope get box => widget as LiteRefScope;
+
+  @override
+  void unmount() {
+    for (final ref in box._cache.values) {
+      ref._dispose();
+    }
+    box._cache.clear();
+    box._overrides?.clear();
+    super.unmount();
+  }
+}

--- a/lib/src/scoped/scope_widget.dart
+++ b/lib/src/scoped/scope_widget.dart
@@ -15,8 +15,10 @@ class LiteRefScope extends InheritedWidget {
   final Set<ScopedRef<dynamic>>? _overrides;
   late final _cache = _Cache();
 
+  // coverage:ignore-start
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
+  // coverage:ignore-end
 
   @override
   InheritedElement createElement() => _Element(this);

--- a/lib/src/scoped/scoped.dart
+++ b/lib/src/scoped/scoped.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/widgets.dart';
+
+part 'scope_widget.dart';
+part 'ref.dart';

--- a/lib/src/sync/sync.dart
+++ b/lib/src/sync/sync.dart
@@ -1,4 +1,4 @@
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 part 'singleton.dart';
 part 'transient.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,17 @@
 name: lite_ref
 description: A lightweight dependency injection package with support for overriding for testing.
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/jinyus/lite_ref
 
 environment:
     sdk: ">=3.0.0 <4.0.0"
+    flutter: ">=3.10.0"
 
 dependencies:
-    meta: ^1.0.0
+    flutter:
+        sdk: flutter
 
 dev_dependencies:
-    test: ^1.19.2
+    flutter_test:
+        sdk: flutter
     very_good_analysis: ^5.1.0

--- a/test/src/async/singleton_test.dart
+++ b/test/src/async/singleton_test.dart
@@ -1,5 +1,5 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:lite_ref/lite_ref.dart';
-import 'package:test/test.dart';
 
 import '../common.dart';
 

--- a/test/src/async/transient_test.dart
+++ b/test/src/async/transient_test.dart
@@ -1,5 +1,5 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:lite_ref/lite_ref.dart';
-import 'package:test/test.dart';
 
 import '../common.dart';
 

--- a/test/src/scoped/ref_test.dart
+++ b/test/src/scoped/ref_test.dart
@@ -51,7 +51,7 @@ void main() {
           home: Builder(
             builder: (context) {
               // This should trigger the error
-              expect(() => countRef(context), throwsArgumentError);
+              expect(() => countRef(context), throwsStateError);
               return const SizedBox.shrink();
             },
           ),

--- a/test/src/scoped/ref_test.dart
+++ b/test/src/scoped/ref_test.dart
@@ -1,10 +1,6 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lite_ref/lite_ref.dart';
-import 'package:lite_ref/src/ref.dart';
 
 void main() {
   test('overriden instance should be equal to main', () {
@@ -55,9 +51,8 @@ void main() {
           home: Builder(
             builder: (context) {
               // This should trigger the error
-              // final val = countRef(context);
               expect(() => countRef(context), throwsArgumentError);
-              return const Text('1');
+              return const SizedBox.shrink();
             },
           ),
         ),
@@ -80,12 +75,17 @@ void main() {
                 overrides: [
                   countRef.overrideWith((ctx) => 2),
                 ],
-                child: Builder(
-                  builder: (context) {
-                    val = countRef(context);
-                    expect(val, 2);
-                    return const SizedBox.shrink();
-                  },
+                child: Column(
+                  children: [
+                    Text('$val'),
+                    Builder(
+                      builder: (context) {
+                        val = countRef(context);
+                        expect(val, 2);
+                        return Text('$val');
+                      },
+                    ),
+                  ],
                 ),
               );
             },
@@ -93,5 +93,8 @@ void main() {
         ),
       ),
     );
+
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('2'), findsOneWidget);
   });
 }

--- a/test/src/scoped/ref_test.dart
+++ b/test/src/scoped/ref_test.dart
@@ -5,13 +5,13 @@ import 'package:lite_ref/lite_ref.dart';
 void main() {
   test('overriden instance should be equal to main', () {
     final countRef = Ref.scoped((ctx) => 1);
-    final countClone = countRef.overrideWith((ctx) => 2);
+    final countRefClone = countRef.overrideWith((ctx) => 2);
 
-    expect(countRef, countClone);
+    expect(countRef, countRefClone);
 
     final hashSet = <Object>{}..add(countRef);
 
-    expect(hashSet.contains(countClone), true);
+    expect(hashSet.contains(countRefClone), true);
   });
 
   testWidgets('should cache values', (tester) async {
@@ -96,5 +96,97 @@ void main() {
 
     expect(find.text('1'), findsOneWidget);
     expect(find.text('2'), findsOneWidget);
+  });
+
+  testWidgets('should be able to use other refs', (tester) async {
+    final ageRef = Ref.scoped((ctx) => 20);
+    final nameRef = Ref.scoped((ctx) => 'John');
+
+    final bioRef = Ref.scoped(
+      (ctx) => '${nameRef(ctx)} is ${ageRef(ctx)} years old',
+    );
+
+    const correctText = 'John is 20 years old';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: Builder(
+            builder: (context) {
+              final val = bioRef(context);
+              expect(val, correctText);
+              return Text(val);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(correctText), findsOneWidget);
+  });
+
+  testWidgets('should dispose ref when scope is unmounted', (tester) async {
+    final disposed = <int>[];
+    final countRef = Ref.scoped((ctx) => 1, dispose: disposed.add);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: Builder(
+            builder: (context) {
+              final val = countRef(context);
+              expect(val, 1);
+              return LiteRefScope(
+                overrides: [
+                  countRef.overrideWith((ctx) => 2),
+                ],
+                child: Builder(
+                  builder: (context) {
+                    final val = countRef(context);
+                    expect(val, 2);
+                    return Text('$val');
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('2'), findsOneWidget);
+
+    expect(disposed, isEmpty);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: Builder(
+            builder: (context) {
+              final val = countRef(context);
+              expect(val, 1);
+              return Text('$val');
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsOneWidget);
+    expect(disposed, [2]); // overriden instance should be disposed
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Text(''),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(disposed, [2, 1]);
   });
 }

--- a/test/src/scoped/ref_test.dart
+++ b/test/src/scoped/ref_test.dart
@@ -1,0 +1,97 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lite_ref/lite_ref.dart';
+import 'package:lite_ref/src/ref.dart';
+
+void main() {
+  test('overriden instance should be equal to main', () {
+    final countRef = Ref.scoped((ctx) => 1);
+    final countClone = countRef.overrideWith((ctx) => 2);
+
+    expect(countRef, countClone);
+
+    final hashSet = <Object>{}..add(countRef);
+
+    expect(hashSet.contains(countClone), true);
+  });
+
+  testWidgets('should cache values', (tester) async {
+    var ran = 0;
+    final countRef = Ref.scoped((ctx) => ++ran);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: Builder(
+            builder: (context) {
+              final val = countRef(context);
+              final val2 = countRef(context);
+              expect(val, 1);
+              expect(val2, 1);
+              return Text('$val $val2');
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(ran, 1);
+
+    final txt = find.text('1 1');
+
+    expect(txt, findsOneWidget);
+  });
+
+  testWidgets(
+    'should throw when there is no root LiteRefScope',
+    (tester) async {
+      final countRef = Ref.scoped((ctx) => 1);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              // This should trigger the error
+              // final val = countRef(context);
+              expect(() => countRef(context), throwsArgumentError);
+              return const Text('1');
+            },
+          ),
+        ),
+      );
+    },
+  );
+
+  testWidgets('overriden instance should have different value', (tester) async {
+    final countRef = Ref.scoped((ctx) => 1);
+    var val = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: Builder(
+            builder: (context) {
+              val = countRef(context);
+              expect(val, 1);
+              return LiteRefScope(
+                overrides: [
+                  countRef.overrideWith((ctx) => 2),
+                ],
+                child: Builder(
+                  builder: (context) {
+                    val = countRef(context);
+                    expect(val, 2);
+                    return const SizedBox.shrink();
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  });
+}

--- a/test/src/sync/singleton_test.dart
+++ b/test/src/sync/singleton_test.dart
@@ -1,5 +1,5 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:lite_ref/lite_ref.dart';
-import 'package:test/test.dart';
 
 import '../common.dart';
 

--- a/test/src/sync/transient_test.dart
+++ b/test/src/sync/transient_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: prefer_const_constructors, cascade_invocations
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:lite_ref/lite_ref.dart';
-import 'package:test/test.dart';
 
 import '../common.dart';
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

#### Scoped Refs

A `ScopedRef` is a reference that needs a build context to access its instance. This is an alternative to `Provider` for classes that don't rebuild widgets. eg: Controllers, Repositories, Services, etc.

-   Wrap your app or subtree with a `LiteRefScope`:

    ```dart
    runApp(
      LiteRefScope(
        child: MyApp(),
      ),
    );
    ```

-   Create a `ScopedRef`.

    ```dart
    final settingsServiceRef = Ref.scoped((ctx) => SettingsService());
    ```

-   Access the instance in the current scope:

    This can be done in a widget by using `settingsServiceRef.of(context)` or `settingsServiceRef(context)`.

    ```dart
    class SettingsPage extends StatelessWidget {
      const SettingsPage({super.key});

      @override
      Widget build(BuildContext context) {
        final settingsService = settingsServiceRef.of(context);
        return Text(settingsService.getThemeMode());
      }
    }
    ```

-   Override it for a subtree:

    You can override the instance for a subtree by using `overrideWith`. This is useful for testing.
    In the example below, all calls to `settingsServiceRef.of(context)` will return `MockSettingsService`.

    ```dart
    LiteRefScope(
        overrides: [
            settingsServiceRef.overrideWith((ctx) => MockSettingsService()),
        ]
        child: MyApp(),
        ),
    ```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
