### PR TITLE
Add exists() method to ScopedRef with tests

### DIFF
--- a/packages/lite_ref/lib/src/scoped/ref.dart
+++ b/packages/lite_ref/lib/src/scoped/ref.dart
@@ -54,6 +54,19 @@ class ScopedRef<T> {
     _instance = _create(context);
   }
 
+  /// Returns `true` if this [ScopedRef] is iniitalized
+  /// in the current [LiteRefScope].
+  bool exists(BuildContext context) {
+    assert(
+      context is Element,
+      'This must be called with the context of a Widget.',
+    );
+
+    final element = LiteRefScope._of(context);
+
+    return element._cache.containsKey(_id);
+  }
+
   /// Returns the instance of [T] in the current scope.
   ///
   /// ```dart

--- a/packages/lite_ref/test/src/scoped/ref_test.dart
+++ b/packages/lite_ref/test/src/scoped/ref_test.dart
@@ -567,6 +567,56 @@ void main() {
       expect(find.text('got: 2'), findsOneWidget);
     },
   );
+  testWidgets(
+    'should return true if the ScopedRef is '
+    'initialized in the current LiteRefScope',
+    (tester) async {
+      final countRef = Ref.scoped((ctx) => 1);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: LiteRefScope(
+            child: Builder(
+              builder: (context) {
+                final initialized = countRef.exists(context);
+                expect(initialized, false);
+
+                final val = countRef.of(context);
+                expect(val, 1);
+
+                final initialized2 = countRef.exists(context);
+                expect(initialized2, true);
+
+                return LiteRefScope(
+                  overrides: [
+                    countRef.overrideWith((ctx) => 2),
+                  ],
+                  child: Builder(
+                    builder: (context) {
+                      final initialized = countRef.exists(context);
+                      expect(initialized, false);
+
+                      final val = countRef.of(context);
+                      expect(val, 2);
+
+                      final initialized2 = countRef.exists(context);
+                      expect(initialized2, true);
+
+                      return Text('$val');
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('2'), findsOneWidget);
+    },
+  );
 }
 
 class _Resource implements Disposable {


### PR DESCRIPTION
## Description

Re: #15

Test used to verify behaviour:

@yousefak007 lmk if it's missing anything.

```dart
final countRef = Ref.scoped((ctx) => 1);

await tester.pumpWidget(
        MaterialApp(
          home: LiteRefScope(
            child: Builder(
              builder: (context) {
                final initialized = countRef.exists(context);
                expect(initialized, false);

                final val = countRef.of(context);
                expect(val, 1);

                final initialized2 = countRef.exists(context);
                expect(initialized2, true);

                return LiteRefScope(
                  overrides: [
                    countRef.overrideWith((ctx) => 2),
                  ],
                  child: Builder(
                    builder: (context) {
                      final initialized = countRef.exists(context);
                      expect(initialized, false);

                      final val = countRef.of(context);
                      expect(val, 2);

                      final initialized2 = countRef.exists(context);
                      expect(initialized2, true);

                      return Text('$val');
                    },
                  ),
                );
              },
            ),
          ),
        ),
      );
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
