### PR TITLE
Feat: Add onlyOverrides param to LiteRefScope

### DIFF
--- a/packages/lite_ref/lib/src/scoped/ref.dart
+++ b/packages/lite_ref/lib/src/scoped/ref.dart
@@ -62,7 +62,7 @@ class ScopedRef<T> {
       'This must be called with the context of a Widget.',
     );
 
-    final element = LiteRefScope._of(context);
+    final element = LiteRefScope._of(context, _id);
 
     return element._cache.containsKey(_id);
   }
@@ -86,7 +86,7 @@ class ScopedRef<T> {
       'This must be called with the context of a Widget.',
     );
 
-    final element = LiteRefScope._of(context);
+    final element = LiteRefScope._of(context, this._id);
 
     final existing = element._cache[_id];
 

--- a/packages/lite_ref/lib/src/scoped/ref.dart
+++ b/packages/lite_ref/lib/src/scoped/ref.dart
@@ -62,7 +62,7 @@ class ScopedRef<T> {
       'This must be called with the context of a Widget.',
     );
 
-    final element = LiteRefScope._of(context, _id);
+    final element = LiteRefScope._of(context, this);
 
     return element._cache.containsKey(_id);
   }
@@ -89,7 +89,7 @@ class ScopedRef<T> {
       'This must be called with the context of a Widget.',
     );
 
-    final element = LiteRefScope._of(context, this._id);
+    final element = LiteRefScope._of(context, this);
 
     final existing = element._cache[_id];
 

--- a/packages/lite_ref/lib/src/scoped/scope_widget.dart
+++ b/packages/lite_ref/lib/src/scoped/scope_widget.dart
@@ -5,13 +5,19 @@ typedef _Cache = Map<Object, ScopedRef<dynamic>>;
 /// Dependency injection of [ScopedRef]s.
 class LiteRefScope extends InheritedWidget {
   /// Create a new [LiteRefScope]
+  /// If [onlyOverrides] is true, only overridden
+  /// ScopedRefs will be provided to children.
   LiteRefScope({
     required super.child,
     super.key,
     List<ScopedRef<dynamic>>? overrides,
+    this.onlyOverrides = false,
   }) : _overrides = overrides?.toSet();
 
   final Set<ScopedRef<dynamic>>? _overrides;
+
+  /// If true, only overridden ScopedRefs will be provided to children.
+  final bool onlyOverrides;
 
   // coverage:ignore-start
   @override

--- a/packages/lite_ref/lib/src/scoped/scope_widget.dart
+++ b/packages/lite_ref/lib/src/scoped/scope_widget.dart
@@ -27,7 +27,7 @@ class LiteRefScope extends InheritedWidget {
   @override
   InheritedElement createElement() => _RefScopeElement(this);
 
-  static _RefScopeElement _of(BuildContext context, Object id) {
+  static _RefScopeElement _of(BuildContext context, ScopedRef<dynamic> ref) {
     final element =
         context.getElementForInheritedWidgetOfExactType<LiteRefScope>();
 
@@ -46,11 +46,11 @@ class LiteRefScope extends InheritedWidget {
 
     final refScopeElement = element! as _RefScopeElement;
 
-    // if the element's widget is onlyOverride, we need to check if the id
+    // if the element's widget is onlyOverride, we need to check if the ref
     // is in the overrides list, if not, we need to visit all ancestors
-    // until we find an element with the id or one that is not onlyOverride
+    // until we find an element with the ref or one that is not onlyOverride
     if (refScopeElement.box.onlyOverrides) {
-      if (refScopeElement.box._overrides?.contains(id) ?? false) {
+      if (refScopeElement.box._overrides?.contains(ref) ?? false) {
         return refScopeElement;
       }
 
@@ -62,7 +62,7 @@ class LiteRefScope extends InheritedWidget {
             newElement = element;
             return false;
           }
-          if (element.box._overrides?.contains(id) ?? false) {
+          if (element.box._overrides?.contains(ref) ?? false) {
             newElement = element;
             return false;
           }
@@ -72,8 +72,8 @@ class LiteRefScope extends InheritedWidget {
 
       if (newElement == null) {
         throw Exception(
-          'Could not find a LiteRefScope with the'
-          ' instance or one that is not marked as onlyOverride',
+          'Could not find a LiteRefScope with "$ref"'
+          ' or one that is not marked as onlyOverride',
         );
       }
 

--- a/packages/lite_ref/lib/src/scoped/scope_widget.dart
+++ b/packages/lite_ref/lib/src/scoped/scope_widget.dart
@@ -7,6 +7,9 @@ class LiteRefScope extends InheritedWidget {
   /// Create a new [LiteRefScope]
   /// If [onlyOverrides] is true, only overridden
   /// ScopedRefs will be provided to children.
+  ///
+  /// If [onlyOverrides] is true, only overridden
+  /// ScopedRefs will be provided to children.
   LiteRefScope({
     required super.child,
     super.key,

--- a/packages/lite_ref/test/src/scoped/ref_test.dart
+++ b/packages/lite_ref/test/src/scoped/ref_test.dart
@@ -779,6 +779,44 @@ void main() {
     expect(find.text('false'), findsOneWidget);
   });
 
+  testWidgets('should fetch from the closest scope/2', (tester) async {
+    final resourceRef = Ref.scoped((ctx) => _Resource());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: Builder(
+            builder: (context) {
+              final val = resourceRef(context);
+              expect(val.disposed, false);
+              val.disposed = true;
+              return LiteRefScope(
+                onlyOverrides: true,
+                overrides: [resourceRef.overrideWith((ctx) => _Resource())],
+                child: Builder(
+                  builder: (context) {
+                    return LiteRefScope(
+                      onlyOverrides: true,
+                      child: Builder(
+                        builder: (context) {
+                          final val2 = resourceRef(context);
+                          expect(val2.disposed, false);
+                          return Text('${val2.disposed}');
+                        },
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('false'), findsOneWidget);
+  });
+
   testWidgets(
     'should fetch from the parent scope when the '
     'closest scope is marked as onlyOverrides',


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

@yousefak007, I think this feature should address your issue.
When  [onlyOverrides] is true, only overridden ScopedRefs will be provided to children.

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
