### PR TITLE
22-fix-show-widget-inspector-resets-the-scoped-state

### DIFF
--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -16,7 +16,7 @@ class Controller {
 final countControllerRef = Ref.scoped((ctx) => Controller());
 
 void main() {
-  runApp(LiteRefScope(child: const MyApp()));
+  runApp(const LiteRefScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/examples/counter/test/widget_test.dart
+++ b/examples/counter/test/widget_test.dart
@@ -12,9 +12,9 @@ extension PumpApp on WidgetTester {
   Future<void> pumpApp(MockCounterController controller) {
     return pumpWidget(
       LiteRefScope(
-        overrides: [
+        overrides: {
           countControllerRef.overrideWith((_) => controller),
-        ],
+        },
         child: const MyApp(),
       ),
     );

--- a/examples/flutter_example/lib/main.dart
+++ b/examples/flutter_example/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter_example/settings/view.dart';
 import 'package:lite_ref/lite_ref.dart';
 
 void main(List<String> args) {
-  runApp(LiteRefScope(child: const MyApp()));
+  runApp(const LiteRefScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/examples/flutter_example/test/widget_test.dart
+++ b/examples/flutter_example/test/widget_test.dart
@@ -34,10 +34,10 @@ void main() {
     // Build our app and trigger a frame.
     await tester.pumpWidget(
       LiteRefScope(
-        overrides: [
+        overrides: {
           settingsServiceRef.overrideWith((_) => mockSettingsService),
           settingsControllerRef.overrideWith((_) => mockSettingsController),
-        ],
+        },
         child: const MyApp(),
       ),
     );

--- a/packages/lite_ref/lib/src/scoped/ref.dart
+++ b/packages/lite_ref/lib/src/scoped/ref.dart
@@ -104,7 +104,7 @@ class ScopedRef<T> {
       return existing._instance as T;
     }
 
-    final refOverride = element.scope._overrides?.lookup(this);
+    final refOverride = element.scope.overrides?.lookup(this);
 
     if (refOverride != null) {
       refOverride._init(context);

--- a/packages/lite_ref/lib/src/scoped/scoped.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped.dart
@@ -1,4 +1,5 @@
 import 'package:basic_interfaces/basic_interfaces.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 part 'scope_widget.dart';

--- a/packages/lite_ref/test/src/scoped/ref_test.dart
+++ b/packages/lite_ref/test/src/scoped/ref_test.dart
@@ -72,9 +72,9 @@ void main() {
               val = countRef(context);
               expect(val, 1);
               return LiteRefScope(
-                overrides: [
+                overrides: {
                   countRef.overrideWith((ctx) => 2),
-                ],
+                },
                 child: Column(
                   children: [
                     Text('$val'),
@@ -137,9 +137,9 @@ void main() {
               final val = countRef(context);
               expect(val, 1);
               return LiteRefScope(
-                overrides: [
+                overrides: {
                   countRef.overrideWith((ctx) => 2),
-                ],
+                },
                 child: Builder(
                   builder: (context) {
                     final val = countRef(context);
@@ -208,9 +208,9 @@ void main() {
               final val = countRef(context);
               expect(val, 1);
               return LiteRefScope(
-                overrides: [
+                overrides: {
                   countRef.overrideWith((ctx) => 2),
-                ],
+                },
                 child: Builder(
                   builder: (context) {
                     final val = countRef(context);
@@ -455,7 +455,7 @@ void main() {
               listenable: show,
               builder: (context, snapshot) {
                 return LiteRefScope(
-                  overrides: [countRef2],
+                  overrides: {countRef2},
                   child: !show.value
                       ? const Text('hidden')
                       : Column(
@@ -530,9 +530,9 @@ void main() {
                       return const SizedBox.shrink();
                     }
                     return LiteRefScope(
-                      overrides: [
+                      overrides: {
                         countRef.overrideWith((_) => 1),
-                      ],
+                      },
                       child: Builder(
                         builder: (context) => child,
                       ),
@@ -546,9 +546,9 @@ void main() {
                       return const SizedBox.shrink();
                     }
                     return LiteRefScope(
-                      overrides: [
+                      overrides: {
                         countRef.overrideWith((_) => 2),
-                      ],
+                      },
                       child: Builder(
                         builder: (context) => child,
                       ),
@@ -588,9 +588,9 @@ void main() {
                 expect(initialized2, true);
 
                 return LiteRefScope(
-                  overrides: [
+                  overrides: {
                     countRef.overrideWith((ctx) => 2),
-                  ],
+                  },
                   child: Builder(
                     builder: (context) {
                       final initialized = countRef.exists(context);
@@ -761,7 +761,7 @@ void main() {
               val.disposed = true;
               return LiteRefScope(
                 onlyOverrides: true,
-                overrides: [resourceRef.overrideWith((ctx) => _Resource())],
+                overrides: {resourceRef.overrideWith((ctx) => _Resource())},
                 child: Builder(
                   builder: (context) {
                     final val2 = resourceRef(context);
@@ -792,7 +792,7 @@ void main() {
               val.disposed = true;
               return LiteRefScope(
                 onlyOverrides: true,
-                overrides: [resourceRef.overrideWith((ctx) => _Resource())],
+                overrides: {resourceRef.overrideWith((ctx) => _Resource())},
                 child: Builder(
                   builder: (context) {
                     return LiteRefScope(
@@ -830,7 +830,7 @@ void main() {
               val.disposed = true;
               return LiteRefScope(
                 onlyOverrides: true,
-                overrides: [resourceRef.overrideWith((ctx) => _Resource())],
+                overrides: {resourceRef.overrideWith((ctx) => _Resource())},
                 child: Builder(
                   builder: (context) {
                     return LiteRefScope(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Fixes bug (https://github.com/jinyus/lite_ref/issues/22)  where refs would be disposed when temporarily deactivated.

Breaking:

The `overrides` parameter is now a Set instead of a List.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
