### PR TITLE
Added ScopedFamilyRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ class CounterView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final contoller = countControllerRef.of(context);
+    final controller = countControllerRef.of(context);
     return ListenableBuilder(
-      listenable: contoller,
+      listenable: controller,
       builder: (context, snapshot) {
-        return Text('${contoller.count}');
+        return Text('${controller.count}');
       },
     );
   }

--- a/README.md
+++ b/README.md
@@ -68,12 +68,44 @@ A `ScopedRef` is a reference that needs a build context to access its instance. 
 
     ```dart
     LiteRefScope(
-        overrides: {
-            settingsServiceRef.overrideWith((ctx) => MockSettingsService()),
-        }
-        child: MyApp(),
-        ),
+      overrides: {
+        settingsServiceRef.overrideWith((ctx) => MockSettingsService()),
+      },
+      child: MyApp(),
+    ),
     ```
+
+A `ScopedFamilyRef` is used when you need to create a unique instance for different keys.
+This is useful for creating multiple instances of the same class with different configurations.
+
+-   Create a `ScopedFamilyRef`.
+
+    ```dart
+    final postControllerRef = Ref.scopedFamily((ctx, String key) {
+      return PostController(key)..fetch();
+    });
+    ```
+-   Access the instance in the current scope:
+
+    This can be done in a widget by using `postController.of(context, key)` or `postController(context, key)`.
+
+    ```dart
+    class PostsPage extends StatelessWidget {
+      const PostsPage({required this.keys, super.key});
+    
+      final List<String> keys;
+
+      @override
+      Widget build(BuildContext context) {
+        return ListView.builder(
+          itemBuilder: (context, index) {
+            final post = postControllerRef.of(context, keys[index]);
+            return Text(post?.title ?? 'Loading...');
+          },
+        );
+      }
+    }
+    ```    
 
 ### Disposal
 

--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -1,8 +1,15 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:lite_ref/lite_ref.dart';
 import 'package:state_beacon/state_beacon.dart';
 
 class Controller {
+  Controller({required this.id});
+
+  final int id;
+
+  String get name => 'counter $id';
   late final _count = Beacon.writable(0);
 
   // we expose it as a readable beacon
@@ -10,10 +17,20 @@ class Controller {
   ReadableBeacon<int> get count => _count;
 
   void increment() => _count.value++;
+
   void decrement() => _count.value--;
+
+  void dispose() {
+    _count.dispose();
+  }
 }
 
-final countControllerRef = Ref.scoped((ctx) => Controller());
+final countersRef = Ref.scoped((context) => Beacon.writable([0]));
+
+final countControllerRef = Ref.scopedFamily(
+  (ctx, int id) => Controller(id: id),
+  dispose: (controller) => controller.dispose(),
+);
 
 void main() {
   runApp(const LiteRefScope(child: MyApp()));
@@ -31,41 +48,116 @@ class MyApp extends StatelessWidget {
           centerTitle: true,
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         ),
-        body: const Center(child: CounterText()),
-        floatingActionButton: const Buttons(),
+        body: const Center(child: Counters()),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            final counters = countersRef.read(context);
+            counters.value = [
+              ...counters.value,
+              counters.value.fold(0, math.max) + 1,
+            ];
+          },
+          child: const Icon(Icons.add_circle_outline),
+        ),
+      ),
+    );
+  }
+}
+
+class Counters extends StatelessWidget {
+  const Counters({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final counters = countersRef.of(context).watch(context);
+
+    return ListView.builder(
+      itemCount: counters.length,
+      itemBuilder: (context, index) {
+        final id = counters[index];
+        return CounterCard(id: id);
+      },
+    );
+  }
+}
+
+class CounterCard extends StatelessWidget {
+  const CounterCard({required this.id, super.key});
+
+  final int id;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = countControllerRef.of(context, id);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Stack(
+          children: [
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  controller.name,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 8),
+                CounterText(id: id),
+                const SizedBox(height: 8),
+                CounterButtons(id: id),
+              ],
+            ),
+            PositionedDirectional(
+              top: 0,
+              end: 0,
+              child: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () {
+                  final counters = countersRef.read(context);
+                  counters.value =
+                      counters.value.where((e) => e != id).toList();
+                },
+              ),
+            )
+          ],
+        ),
       ),
     );
   }
 }
 
 class CounterText extends StatelessWidget {
-  const CounterText({super.key});
+  const CounterText({required this.id, super.key});
+
+  final int id;
 
   @override
   Widget build(BuildContext context) {
-    final controller = countControllerRef.of(context);
+    final controller = countControllerRef.of(context, id);
     final count = controller.count.watch(context);
     final theme = Theme.of(context);
     return Text('$count', style: theme.textTheme.displayLarge);
   }
 }
 
-class Buttons extends StatelessWidget {
-  const Buttons({super.key});
+class CounterButtons extends StatelessWidget {
+  const CounterButtons({required this.id, super.key});
+
+  final int id;
 
   @override
   Widget build(BuildContext context) {
-    final controller = countControllerRef.of(context);
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.end,
-      crossAxisAlignment: CrossAxisAlignment.end,
+    final controller = countControllerRef.of(context, id);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        FloatingActionButton(
+        FilledButton(
           onPressed: controller.increment,
           child: const Icon(Icons.add),
         ),
-        const SizedBox(height: 8),
-        FloatingActionButton(
+        const SizedBox(width: 8),
+        FilledButton(
           onPressed: controller.decrement,
           child: const Icon(Icons.remove),
         ),

--- a/examples/counter/pubspec.lock
+++ b/examples/counter/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: "../../packages/lite_ref"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   lite_ref_core:
     dependency: transitive
     description:

--- a/examples/counter/pubspec.lock
+++ b/examples/counter/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: "../../packages/lite_ref"
       relative: true
     source: path
-    version: "0.6.3"
+    version: "0.7.0"
   lite_ref_core:
     dependency: transitive
     description:

--- a/examples/counter/test/controller_test.dart
+++ b/examples/counter/test/controller_test.dart
@@ -4,7 +4,7 @@ import 'package:state_beacon/state_beacon.dart';
 
 void main() {
   test('emits [1] when incremented', () {
-    final controller = Controller();
+    final controller = Controller(id: 0);
 
     expect(controller.count.value, 0);
 
@@ -16,7 +16,7 @@ void main() {
   });
 
   test('emits [-1] when decremented', () {
-    final controller = Controller();
+    final controller = Controller(id: 0);
 
     expect(controller.count.value, 0);
 

--- a/examples/counter/test/widget_test.dart
+++ b/examples/counter/test/widget_test.dart
@@ -13,7 +13,7 @@ extension PumpApp on WidgetTester {
     return pumpWidget(
       LiteRefScope(
         overrides: {
-          countControllerRef.overrideWith((_) => controller),
+          countControllerRef.overrideWith((_, __) => controller),
         },
         child: const MyApp(),
       ),
@@ -22,7 +22,13 @@ extension PumpApp on WidgetTester {
 }
 
 void main() {
-  final controller = MockCounterController();
+  late final MockCounterController controller;
+
+  setUpAll(() {
+    registerFallbackValue(Beacon.writable(0));
+    controller = MockCounterController();
+    when(() => controller.name).thenReturn('counter 0');
+  });
 
   testWidgets('renders current count', (tester) async {
     final beacon = Beacon.writable(42);

--- a/examples/flutter_example/pubspec.lock
+++ b/examples/flutter_example/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: "../../packages/lite_ref"
       relative: true
     source: path
-    version: "0.6.3"
+    version: "0.7.0"
   lite_ref_core:
     dependency: transitive
     description:

--- a/packages/lite_ref/README.md
+++ b/packages/lite_ref/README.md
@@ -104,11 +104,11 @@ class CounterView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final contoller = countControllerRef.of(context);
+    final controller = countControllerRef.of(context);
     return ListenableBuilder(
-      listenable: contoller,
+      listenable: controller,
       builder: (context, snapshot) {
-        return Text('${contoller.count}');
+        return Text('${controller.count}');
       },
     );
   }

--- a/packages/lite_ref/lib/src/ref.dart
+++ b/packages/lite_ref/lib/src/ref.dart
@@ -6,6 +6,7 @@ import 'package:lite_ref_core/lite_ref_core.dart';
 /// abstract class for creating refs.
 /// ```dart
 /// final scoped = Ref.scoped((context) => AuthService());
+/// final scopedFamily = Ref.scopedFamily((context, id) => ProductService(id));
 /// final singleton = Ref.singleton(() => Database());
 /// final transient = Ref.transient(() => APIClient());
 /// ```
@@ -63,6 +64,71 @@ abstract class Ref {
     bool autoDispose = true,
   }) {
     return ScopedRef<T>(create, dispose: dispose, autoDispose: autoDispose);
+  }
+
+  /// Creates a new [ScopedFamilyRef] which requires a context and family value
+  /// to access the instance.
+  /// The family value must be immutable and implement `==` and `hashCode`.
+  ///
+  ///  -   Wrap your app or a subtree with a `LiteRefScope`:
+  ///
+  ///      ```dart
+  ///      runApp(
+  ///        LiteRefScope(
+  ///          child: MyApp(),
+  ///        ),
+  ///      );
+  ///      ```
+  ///
+  ///  -   Create a `ScopedFamilyRef`.
+  ///
+  ///      ```dart
+  ///      final productControllerRef = Ref.scopedFamily((BuildContext context, int id) => ProductController(id: id));
+  ///      ```
+  ///
+  ///  -   Access the instance in the current scope:
+  ///
+  ///      This can be done in a widget by using `productRef.of(context, 42)` or `settingsServiceRef(context, 42)`.
+  ///
+  ///      ```dart
+  ///      class ProductWidget extends StatelessWidget {
+  ///        const SettingsPage({required this.id, super.key});
+  ///
+  ///        final int id;
+  ///
+  ///        @override
+  ///        Widget build(BuildContext context) {
+  ///          final productController = productControllerRef.of(context, id);
+  ///          return Text(productController.getName());
+  ///        }
+  ///      }
+  ///      ```
+  ///
+  ///  -   Override it for a subtree:
+  ///
+  ///      You can override the instance for a subtree by using `overrideWith`. This is useful for testing.
+  ///      In the example below, all calls to `settingsServiceRef.of(context)` will return `MockSettingsService`.
+  ///
+  ///      ```dart
+  ///      LiteRefScope(
+  ///        overrides: [
+  ///          settingsServiceRef.overrideWith((ctx, int id) {
+  ///            return switch(id) {
+  ///              0 => MockProductController0(),
+  ///              42 => MockProductController42(),
+  ///              _ => MockProductController(id: id),
+  ///            };
+  ///          }),
+  ///        ],
+  ///        child: MyApp(),
+  ///      ),
+  ///      ```
+  static ScopedFamilyRef<T, F> scopedFamily<T, F>(
+    CtxFamilyCreateFn<T, F> create, {
+    DisposeFn<T>? dispose,
+    bool autoDispose = true,
+  }) {
+    return ScopedFamilyRef<T, F>(create, dispose: dispose, autoDispose: autoDispose);
   }
 
   // coverage:ignore-start

--- a/packages/lite_ref/lib/src/scoped/i_scoped_ref.dart
+++ b/packages/lite_ref/lib/src/scoped/i_scoped_ref.dart
@@ -1,0 +1,17 @@
+part of 'scoped.dart';
+
+/// The function used to create an instance of [T].
+typedef CtxCreateFn<T> = T Function(BuildContext context);
+
+/// The function used to create an instance of [T] with a family [F].
+typedef CtxFamilyCreateFn<T, F> = T Function(BuildContext context, F family);
+
+/// The function called when the [IScopedRef] is disposed.
+typedef DisposeFn<T> = void Function(T);
+
+/// A [ScopedRef] is a reference that needs a context to access the instance.
+sealed class IScopedRef<T> {
+  /// Whether the instance should be disposed when all the widgets that have
+  /// access to the instance are unmounted.
+  bool get autoDispose;
+}

--- a/packages/lite_ref/lib/src/scoped/scope_widget.dart
+++ b/packages/lite_ref/lib/src/scoped/scope_widget.dart
@@ -1,6 +1,6 @@
 part of 'scoped.dart';
 
-typedef _Cache = Map<Object, ScopedRef<dynamic>>;
+typedef _Cache = Map<Object, ScopedObject<dynamic>>;
 
 /// Dependency injection of [ScopedRef]s.
 class LiteRefScope extends InheritedWidget {
@@ -18,7 +18,7 @@ class LiteRefScope extends InheritedWidget {
   });
 
   /// List of ScopedRefs to override.
-  final Set<ScopedRef<dynamic>>? overrides;
+  final Set<IScopedRef<dynamic>>? overrides;
 
   /// If true, only overridden ScopedRefs will be provided to children.
   final bool onlyOverrides;
@@ -31,7 +31,7 @@ class LiteRefScope extends InheritedWidget {
   @override
   InheritedElement createElement() => _RefScopeElement(this);
 
-  static _RefScopeElement _of(BuildContext context, ScopedRef<dynamic> ref) {
+  static _RefScopeElement _of(BuildContext context, IScopedRef<dynamic> ref) {
     final element =
         context.getElementForInheritedWidgetOfExactType<LiteRefScope>();
 
@@ -95,9 +95,9 @@ class _RefScopeElement extends InheritedElement {
 
   late final _cache = _Cache();
 
-  late final _autoDisposeBindings = <Element, Set<ScopedRef<dynamic>>>{};
+  late final _autoDisposeBindings = <Element, Set<ScopedObject<dynamic>>>{};
 
-  void _addAutoDisposeBinding(Element element, ScopedRef<dynamic> ref) {
+  void _addAutoDisposeBinding(Element element, ScopedObject<dynamic> ref) {
     final existing = _autoDisposeBindings[element];
 
     if (existing != null) {

--- a/packages/lite_ref/lib/src/scoped/scoped.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped.dart
@@ -1,6 +1,10 @@
 import 'package:basic_interfaces/basic_interfaces.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
+import 'package:lite_ref/lite_ref.dart';
 
+part 'i_scoped_ref.dart';
 part 'scope_widget.dart';
-part 'ref.dart';
+part 'scoped_family_ref.dart';
+part 'scoped_ref.dart';
+part 'scoped_object.dart';

--- a/packages/lite_ref/lib/src/scoped/scoped_family_ref.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped_family_ref.dart
@@ -1,0 +1,171 @@
+part of 'scoped.dart';
+
+/// A [ScopedFamilyRef] is a reference that needs a context to access instances.
+@immutable
+class ScopedFamilyRef<T, F> implements IScopedRef<T> {
+  ///  Creates a new [ScopedFamilyRef] which always return new instances.
+  /// If [autoDispose] is set to `true`, a instance will be disposed when
+  /// all the widgets that have access to instance are unmounted.
+  ///
+  /// A [dispose] function does not have to be provided if [T] implements
+  /// [Disposable].
+  ScopedFamilyRef(
+    CtxFamilyCreateFn<T, F> create, {
+    DisposeFn<T>? dispose,
+    this.autoDispose = true,
+  })  : _create = create,
+        _onDispose = dispose,
+        _id = Object();
+
+  const ScopedFamilyRef._(
+    CtxFamilyCreateFn<T, F> create,
+    Object id, {
+    required this.autoDispose,
+    DisposeFn<T>? dispose,
+  })  : _create = create,
+        _id = id,
+        _onDispose = dispose;
+
+  final Object _id;
+
+  /// Whether the instance should be disposed when all the widgets that have
+  /// access to the instance are unmounted.
+  @override
+  final bool autoDispose;
+
+  final DisposeFn<T>? _onDispose;
+
+  final CtxFamilyCreateFn<T, F> _create;
+
+  ScopedObject<T> _createRefObject(BuildContext context, F family) {
+    final refObject = ScopedObject<T>(
+      id: (_id, family),
+      dispose: _onDispose,
+      instance: _create(context, family),
+      autoDispose: autoDispose,
+    );
+    return refObject;
+  }
+
+  /// Returns `true` if this [ScopedFamilyRef] with that [family] is initialized
+  /// in the current [LiteRefScope].
+  bool exists(BuildContext context, F family) {
+    assert(
+      context is Element,
+      'This must be called with the context of a Widget.',
+    );
+
+    final element = LiteRefScope._of(context, this);
+
+    return element._cache.containsKey((_id, family));
+  }
+
+  /// Returns the instance of [T] in the current scope for that family.
+  ///
+  /// If [listen] is `false`, the instance will not be disposed when the widget
+  /// is unmounted.
+  ///
+  /// ```dart
+  /// class ProductWidget extends StatelessWidget {
+  ///   const SettingsPage({required this.id, super.key});
+  ///
+  ///   final int id;
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     final productController = productControllerRef.of(context, id);
+  ///     return Text(productController.getName());
+  ///   }
+  /// }
+  /// ```
+
+  T of(BuildContext context, F family, {bool listen = true}) {
+    assert(
+      context is Element,
+      'This must be called with the context of a Widget.',
+    );
+
+    final element = LiteRefScope._of(context, this);
+
+    final existing = element._cache[(_id, family)];
+
+    void autoDisposeIfNeeded(ScopedObject<dynamic> ref) {
+      if (autoDispose && listen) {
+        element._addAutoDisposeBinding(context as Element, ref);
+      }
+    }
+
+    if (existing != null) {
+      autoDisposeIfNeeded(existing);
+      return existing._instance as T;
+    }
+
+    final refOverride = element.scope.overrides?.lookup(this);
+
+    if (refOverride != null) {
+      final refObject =
+          (refOverride as ScopedFamilyRef)._createRefObject(context, family);
+      element._cache[refObject._id] = refObject;
+      autoDisposeIfNeeded(refObject);
+      return refObject._instance as T;
+    }
+
+    final refObject = _createRefObject(context, family);
+
+    autoDisposeIfNeeded(refObject);
+
+    element._cache[refObject._id] = refObject;
+
+    return refObject._instance;
+  }
+
+  /// Returns the instance of [T] in the current scope without disposing it
+  /// when the widget is unmounted. This should be used in callbacks like
+  /// `onPressed` or `onTap`.
+  ///
+  /// Alias for `of(context, family, listen: false)`.
+  T read(BuildContext context, F family) {
+    return of(context, family, listen: false);
+  }
+
+  /// Equivalent to calling the [of(context, family)] getter.
+  T call(BuildContext context, F family) => of(context, family);
+
+  /// Returns a new ScopedFamilyRef with a different [create] function.
+  /// When used with a [LiteRefScope] overrides, any child widget that accesses
+  /// the instance will use the new [create] function.
+  ///
+  /// Set [autoDispose] to `false` if you're overriding with an existing
+  /// instance and you don't want the instance to be disposed
+  /// when all the widgets that have access to it are unmounted.
+  ///```dart
+  ///LiteRefScope(
+  ///    overrides: [
+  ///       productServiceRef.overrideWith((ctx, _) => MockProductService()),
+  ///    ]
+  ///    child: MyApp(),
+  ///    ),
+  ///```
+  ScopedFamilyRef<T, F> overrideWith(
+    CtxFamilyCreateFn<T, F> create, {
+    bool autoDispose = true,
+  }) {
+    return ScopedFamilyRef._(
+      create,
+      _id,
+      dispose: autoDispose ? _onDispose : null,
+      autoDispose: autoDispose,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (runtimeType != other.runtimeType) return false;
+    if (other is ScopedFamilyRef<T, F>) return _id == other._id;
+    return false;
+  }
+
+  @override
+  int get hashCode => _id.hashCode;
+}

--- a/packages/lite_ref/lib/src/scoped/scoped_object.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped_object.dart
@@ -28,9 +28,6 @@ class ScopedObject<T> {
 
   int _watchCount = 0;
 
-  /// The number of widgets that are currently watching this instance.
-  int get watchCount => _watchCount;
-
   void _dispose() {
     if (_instance == null) return;
     _onDispose?.call(_instance);

--- a/packages/lite_ref/lib/src/scoped/scoped_object.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped_object.dart
@@ -1,0 +1,46 @@
+part of 'scoped.dart';
+
+/// A [ScopedObject] is a reference that holds an instance of [T].
+///
+/// If [autoDispose] is set to `true`, the instance will be disposed when
+/// all the widgets that have access to the instance are unmounted.
+class ScopedObject<T> {
+
+  /// Creates a new [ScopedObject] with an [id] and an [instance].
+  ScopedObject({
+    required Object id,
+    required T instance,
+    DisposeFn<T>? dispose,
+    this.autoDispose = true,
+  })  : _id = id,
+        _onDispose = dispose,
+        _instance = instance;
+
+  final T _instance;
+
+  final Object _id;
+
+  /// Whether the instance should be disposed when all the widgets that have
+  /// access to the instance are unmounted.
+  final bool autoDispose;
+
+  final DisposeFn<T>? _onDispose;
+
+  int _watchCount = 0;
+
+  /// The number of widgets that are currently watching this instance.
+  int get watchCount => _watchCount;
+
+  void _dispose() {
+    if (_instance == null) return;
+    _onDispose?.call(_instance);
+    if (autoDispose && _onDispose == null) {
+      if (_instance case final Disposable d) {
+        d.dispose();
+      } else if (_instance case final ChangeNotifier c) {
+        // covers ChangeNotifier and ValueNotifier
+        c.dispose();
+      }
+    }
+  }
+}

--- a/packages/lite_ref/lib/src/scoped/scoped_ref.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped_ref.dart
@@ -1,15 +1,8 @@
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-
 part of 'scoped.dart';
 
-/// The function used to create an instance of [T].
-typedef CtxCreateFn<T> = T Function(BuildContext);
-
-/// The function called when the [ScopedRef] is disposed.
-typedef DisposeFn<T> = void Function(T);
-
 /// A [ScopedRef] is a reference that needs a context to access the instance.
-class ScopedRef<T> {
+@immutable
+class ScopedRef<T> implements IScopedRef<T> {
   ///  Creates a new [ScopedRef] which always return a new instance.
   /// If [autoDispose] is set to `true`, the instance will be disposed when
   /// all the widgets that have access to the instance are unmounted.
@@ -24,7 +17,7 @@ class ScopedRef<T> {
         _onDispose = dispose,
         _id = Object();
 
-  ScopedRef._(
+  const ScopedRef._(
     CtxCreateFn<T> create,
     Object id, {
     required this.autoDispose,
@@ -37,24 +30,24 @@ class ScopedRef<T> {
 
   /// Whether the instance should be disposed when all the widgets that have
   /// access to the instance are unmounted.
+  @override
   final bool autoDispose;
 
   final DisposeFn<T>? _onDispose;
 
-  T? _instance;
-
-  int _watchCount = 0;
-
-  /// The number of widgets that have access to the instance.
-  int get watchCount => _watchCount;
-
   final CtxCreateFn<T> _create;
 
-  void _init(BuildContext context) {
-    _instance = _create(context);
+  ScopedObject<T> _createRefObject(BuildContext context) {
+    final refObject = ScopedObject<T>(
+      id: _id,
+      dispose: _onDispose,
+      instance: _create(context),
+      autoDispose: autoDispose,
+    );
+    return refObject;
   }
 
-  /// Returns `true` if this [ScopedRef] is iniitalized
+  /// Returns `true` if this [ScopedRef] is initialized
   /// in the current [LiteRefScope].
   bool exists(BuildContext context) {
     assert(
@@ -69,7 +62,7 @@ class ScopedRef<T> {
 
   /// Returns the instance of [T] in the current scope.
   ///
-  /// If [listen] is `false`, theinstance will not be disposed when the widget
+  /// If [listen] is `false`, the instance will not be disposed when the widget
   /// is unmounted.
   ///
   /// ```dart
@@ -93,7 +86,7 @@ class ScopedRef<T> {
 
     final existing = element._cache[_id];
 
-    void autoDisposeIfNeeded(ScopedRef<dynamic> ref) {
+    void autoDisposeIfNeeded(ScopedObject<dynamic> ref) {
       if (autoDispose && listen) {
         element._addAutoDisposeBinding(context as Element, ref);
       }
@@ -107,19 +100,19 @@ class ScopedRef<T> {
     final refOverride = element.scope.overrides?.lookup(this);
 
     if (refOverride != null) {
-      refOverride._init(context);
-      element._cache[_id] = refOverride;
-      autoDisposeIfNeeded(refOverride);
-      return refOverride._instance as T;
+      final refObject = (refOverride as ScopedRef)._createRefObject(context);
+      element._cache[refObject._id] = refObject;
+      autoDisposeIfNeeded(refObject);
+      return refObject._instance as T;
     }
 
-    autoDisposeIfNeeded(this);
+    final refObject = _createRefObject(context);
 
-    _init(context);
+    autoDisposeIfNeeded(refObject);
 
-    element._cache[_id] = this;
+    element._cache[refObject._id] = refObject;
 
-    return _instance as T;
+    return refObject._instance;
   }
 
   /// Returns the instance of [T] in the current scope without disposing it
@@ -138,7 +131,7 @@ class ScopedRef<T> {
   /// When used with a [LiteRefScope] overrides, any child widget that accesses
   /// the instance will use the new [create] function.
   ///
-  /// Set [autoDispose] to `false` if you're overridding with an existing
+  /// Set [autoDispose] to `false` if you're overriding with an existing
   /// instance and you don't want the instance to be disposed
   /// when all the widgets that have access to it are unmounted.
   ///```dart
@@ -156,19 +149,6 @@ class ScopedRef<T> {
       dispose: autoDispose ? _onDispose : null,
       autoDispose: autoDispose,
     );
-  }
-
-  void _dispose() {
-    if (_instance == null) return;
-    _onDispose?.call(_instance as T);
-    if (autoDispose && _onDispose == null) {
-      if (_instance case final Disposable d) {
-        d.dispose();
-      } else if (_instance case final ChangeNotifier c) {
-        // covers ChangeNotifier and ValueNotifier
-        c.dispose();
-      }
-    }
   }
 
   @override

--- a/packages/lite_ref/pubspec.yaml
+++ b/packages/lite_ref/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lite_ref
 description: A lightweight dependency injection package with support for overriding for testing.
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/jinyus/lite_ref
 
 environment:

--- a/packages/lite_ref/test/src/scoped/ref_test.dart
+++ b/packages/lite_ref/test/src/scoped/ref_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lite_ref/lite_ref.dart';
 
 void main() {
-  test('overridden instance should be equal to main', () {
+  test('overriden instance should be equal to main', () {
     final countRef = Ref.scoped((ctx) => 1);
     final countRefClone = countRef.overrideWith((ctx) => 2);
 
@@ -60,8 +60,7 @@ void main() {
     },
   );
 
-  testWidgets('overridden instance should have different value',
-      (tester) async {
+  testWidgets('overriden instance should have different value', (tester) async {
     final countRef = Ref.scoped((ctx) => 1);
     var val = 0;
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
https://github.com/jinyus/lite_ref/issues/25#issue-2243685794

@jinyus 

I suggest the following interface and implementation for the family feature.
I am still in the process of writing tests and examples, but at the moment I am interested in opinions about the API and the fact that the `watchCount` will become unavailable for retrieval from `ScopedRef` since the state has been moved into a separate object.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [x] 📝 Documentation
-   [ ] 🗑️ Chore
