### PR TITLE
[Fix] Bug with disposing wrong instance

### DIFF
--- a/packages/lite_ref/lib/src/scoped/ref.dart
+++ b/packages/lite_ref/lib/src/scoped/ref.dart
@@ -158,6 +158,15 @@ class ScopedRef<T> {
     );
   }
 
+  ScopedRef<T> _copy() {
+    return ScopedRef._(
+      _create,
+      _id,
+      dispose: _onDispose,
+      autoDispose: autoDispose,
+    ).._instance = _instance;
+  }
+
   void _dispose() {
     if (_instance == null) return;
     _onDispose?.call(_instance as T);

--- a/packages/lite_ref/lib/src/scoped/scope_widget.dart
+++ b/packages/lite_ref/lib/src/scoped/scope_widget.dart
@@ -131,11 +131,13 @@ class _RefScopeElement extends InheritedElement {
     super.deactivate();
   }
 
+// coverage:ignore-start
   @override
   void activate() {
     super.activate();
     _oldRefs.clear();
   }
+// coverage:ignore-end
 
   @override
   void removeDependent(Element dependent) {

--- a/packages/lite_ref/lib/src/scoped/scope_widget.dart
+++ b/packages/lite_ref/lib/src/scoped/scope_widget.dart
@@ -97,6 +97,8 @@ class _RefScopeElement extends InheritedElement {
 
   late final _autoDisposeBindings = <Element, Set<ScopedRef<dynamic>>>{};
 
+  late final _oldRefs = <ScopedRef<dynamic>>[];
+
   void _addAutoDisposeBinding(Element element, ScopedRef<dynamic> ref) {
     final existing = _autoDisposeBindings[element];
 
@@ -117,6 +119,22 @@ class _RefScopeElement extends InheritedElement {
     _parent = parent?.getElementForInheritedWidgetOfExactType<LiteRefScope>()
         as _RefScopeElement?;
     super.mount(parent, newSlot);
+  }
+
+  @override
+  void deactivate() {
+    // if this widget gets replaced by another LiteRefScope
+    // (eg: hot-reload when it or one of its ancestors has a UniqueKey).
+    // We need to store a copy of all Refs in our cache so we don't dispose
+    // refs being used by its replacement.
+    _oldRefs.addAll(_cache.values.map((e) => e._copy()));
+    super.deactivate();
+  }
+
+  @override
+  void activate() {
+    super.activate();
+    _oldRefs.clear();
   }
 
   @override
@@ -146,10 +164,16 @@ class _RefScopeElement extends InheritedElement {
 
   @override
   void unmount() {
-    for (final ref in _cache.values) {
+    // this shouldn't be necessary but it's harmless
+    // we should be able to just use _oldRefs.
+    final toBeDisposed = _oldRefs.isEmpty ? _cache.values : _oldRefs;
+
+    for (final ref in toBeDisposed) {
       ref._dispose();
     }
+
     _cache.clear();
+    _oldRefs.clear();
     scope.overrides?.clear();
     _autoDisposeBindings.clear();
     _parent = null;

--- a/packages/lite_ref/lib/src/scoped/scoped_object.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped_object.dart
@@ -5,7 +5,6 @@ part of 'scoped.dart';
 /// If [autoDispose] is set to `true`, the instance will be disposed when
 /// all the widgets that have access to the instance are unmounted.
 class ScopedObject<T> {
-
   /// Creates a new [ScopedObject] with an [id] and an [instance].
   ScopedObject({
     required Object id,
@@ -27,6 +26,10 @@ class ScopedObject<T> {
   final DisposeFn<T>? _onDispose;
 
   int _watchCount = 0;
+
+  ScopedObject<T> _copy() {
+    return ScopedObject(id: _id, instance: _instance);
+  }
 
   void _dispose() {
     if (_instance == null) return;

--- a/packages/lite_ref/lib/src/scoped/scoped_object.dart
+++ b/packages/lite_ref/lib/src/scoped/scoped_object.dart
@@ -28,7 +28,12 @@ class ScopedObject<T> {
   int _watchCount = 0;
 
   ScopedObject<T> _copy() {
-    return ScopedObject(id: _id, instance: _instance);
+    return ScopedObject(
+      id: _id,
+      instance: _instance,
+      autoDispose: autoDispose,
+      dispose: _onDispose,
+    );
   }
 
   void _dispose() {

--- a/packages/lite_ref/test/src/scoped/ref_test.dart
+++ b/packages/lite_ref/test/src/scoped/ref_test.dart
@@ -893,6 +893,65 @@ void main() {
     },
   );
 
+  testWidgets('should dispose correct ref when scope has UniqueKey',
+      (tester) async {
+    final disposed = <int>[];
+    final countRef = Ref.scoped(
+      (ctx) => 1,
+      dispose: disposed.add,
+    );
+
+    final inc = ValueNotifier(1);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiteRefScope(
+          child: ListenableBuilder(
+            listenable: inc,
+            builder: (context, _) {
+              return Container(
+                key: UniqueKey(),
+                child: LiteRefScope(
+                  overrides: {
+                    countRef.overrideWith((ctx) => 1 + inc.value),
+                  },
+                  child: Builder(
+                    builder: (context) {
+                      final val = countRef(context);
+                      return Text('$val');
+                    },
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('2'), findsOneWidget);
+
+    expect(disposed, isEmpty);
+
+    inc.value = 2;
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('3'), findsOneWidget);
+
+    expect(disposed, [2]);
+
+    inc.value = 3;
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('4'), findsOneWidget);
+
+    expect(disposed, [2, 3]);
+  });
+
   group('ScopedFamilyRef', () {
     test('overridden instance should be equal to main', () {
       final countRef = Ref.scopedFamily((ctx, int a) => 1);


### PR DESCRIPTION
## Description

When a LiteRefScope was replace by another one (eg: On hot-reload when it or one of its ancestors has a UniqueKey) it would dispose the wrong instance in some situations.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
